### PR TITLE
add original name type to timetable types

### DIFF
--- a/src/Raw_Edulink_Response_Types/Edulink_Timetable.ts
+++ b/src/Raw_Edulink_Response_Types/Edulink_Timetable.ts
@@ -32,6 +32,7 @@ type Edulink_Timetable_Day = {
   id: number;
   date: string;
   name: string;
+  original_name: string;
   is_current: boolean;
   periods: Edulink_Timetable_Period[];
   lessons: Edulink_Timetable_Lesson[];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50714675/162584252-1891f39f-6d27-4777-810d-2adaa1b99da2.png)
Hi, thanks for making this package! The day is currently missing the `original_name` type, shown in the image. I'm fetching this data like this:
```ts
let apiTimetable = (await Edulink.Edulink_Raw.Timetable(date)).result;
```

```json
        "cycle_day_id": "958",
        "name": "Monday",
        "original_name": "Mon2",
        "date": "2022-04-25",
        "is_current": true,
```